### PR TITLE
Optimize release compilation

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bbb release monolithic:release
+web: bbb monolithic:release

--- a/README.md
+++ b/README.md
@@ -58,16 +58,13 @@ If you do, that's a good thing! Because, now you can go to [http://localhost:800
 
 ### Hosting on Heroku
 
-Blockee is actually ready to host on your own Heroku instance. The Procfile defines a web worker that assumes you've created a release distribution of Blockee. To create a release run the following grunt command:
-
-    $ bbb clean
-    $ bbb release
-
-This will remove/update the dist/release files with any changes you might have made. Now you can do the typical heroku create, git push heroku master steps to push the site to your heroku app.
+Blockee is already ready to host on your own Heroku instance. When deploying to Heroku, your javascript and css will be automatically concatenated/compiled for faster loading. You can do the typical heroku create, git push heroku master steps to push the site to your heroku app.
     
-To test your release locally, run the site via the Procfile (this assumes you are somewhat familiar with heroku and have foreman installed). Specifically, run:
+To test this concatenated/compilation release locally, run:
 
-    $ foreman start
+    $ bbb clean release monolithic:release
+    
+This will remove any previously compiled static assets, re-compile static assets, then start your local testing server (but using compiled assets, not development ones). Now visit [http://localhost:8000/](http://localhost:8000/).
 
 ### Thanks!
 

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1,2 +1,4 @@
-@import "h5bp.css";
-@import "style.css";
+/* Only import stylesheets here. Make sure to also add them to grunt.js */
+@import "bootstrap.css";
+@import "main.css";
+@import "bootstrap-responsive.css";

--- a/grunt.js
+++ b/grunt.js
@@ -70,8 +70,9 @@ module.exports = function(grunt) {
     // only want to load one stylesheet in index.html.
     mincss: {
       "dist/release/index.css": [
-        "assets/css/h5bp.css",
-        "assets/css/style.css"
+        "assets/css/bootstrap.css",
+        "assets/css/main.css",
+        "assets/css/bootstrap-responsive.css"
       ]
     },
 
@@ -253,13 +254,17 @@ module.exports = function(grunt) {
 
     site.use(express.bodyParser());
 
-    // Serve static files
+    // Serve grunt.js specified static file routes.
+    // Because these come first, they will override the default routes below.
+    if (typeof options.folders !== 'undefined') {
+      for (var path in options.folders) {
+        site.use('/' + path, express.static(__dirname + '/' + options.folders[path]));
+      }
+    }
+
+    // Serve default static file routes
     site.use("/app", express.static(__dirname + '/app'));
-    site.use("/assets/js/libs", express.static(__dirname + '/assets/js/libs'));
-    site.use("/assets/js/plugins", express.static(__dirname + '/assets/js/plugins')); 
-    site.use("/assets/css", express.static(__dirname + '/assets/css'));
-    site.use("/assets/img", express.static(__dirname + '/assets/img'));
-    site.use("/dist", express.static(__dirname + '/dist'));
+    site.use("/assets", express.static(__dirname + '/assets'));
     site.use("/tmp", express.static(__dirname + '/tmp'));
 
     // Serve favicon.ico

--- a/index.html
+++ b/index.html
@@ -8,9 +8,7 @@
   <meta name="description" content="Better your neighborhood with bling. A Labs Friday project of Code for America.">
   <title>blockee</title>
   <!-- Application styles -->
-  <link rel="stylesheet" href="/assets/css/bootstrap.css">
-  <link rel="stylesheet" href="/assets/css/bootstrap-responsive.css">
-  <link rel="stylesheet" href="/assets/css/main.css">
+  <link rel="stylesheet" href="/assets/css/index.css">
   <link href='http://fonts.googleapis.com/css?family=Rokkitt:400,700' rel='stylesheet' type='text/css'>
   <!-- kiss analytics -->
   <script type="text/javascript">

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   },
   "engines": {
     "node": "0.6.x"
+  },
+  "scripts": {
+    "install": "bbb release --force"
   }
 }


### PR DESCRIPTION
This pull request changes how the static assets are compiled when deploying: the "release" step has been removed from the Procfile and put into `package.json` as an install script. This means that assets are compiled only when new code is pushed to Heroku *not* every time the server is restarted.  This means that Blockee will be able to "wake up" significantly faster if the Heroku instance is spun down.

Also, I refactored how the routes for static assets are set. It now pulls the routes as defined in the grunt.js configuration, removes redundant routes, and properly orders the routes to make sure that explicitly defined routes override default ones (e.g. when running `monolithic:release`). 

Related: I would highly recommend you update your version of `bbb` as it's now 10 releases behind. If you do so, I would also recommend separating your server config/routes from your public asset compilation (e.g. grunt.js). You can see how I did this in [Super Mayor](https://github.com/bensheldon/super-mayor) by:

1. moving all public assets into a `/public` folder
2. performing compilation in an [NPM install hook](https://github.com/bensheldon/super-mayor/blob/master/package.json#L9)
3. serving development/release(compiled) assets depending on npm's [configuration environment](https://github.com/bensheldon/super-mayor/blob/master/server.js#L28) (e.g. `NODE_ENV`)

This makes maintaining the server much easier since it's separate from all the grunt.js cruft; it also makes updating bbb *much* easier (you're missing out on some sweet configuration/compilation improvements in both bbb and backbone-boilerplate)