### PR TITLE
Patched blockee server

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,6 @@ module.exports = function(grunt) {
   var log = grunt.log;
 
   grunt.initConfig({
-
     // The clean task ensures all files are removed from the dist/ directory so
     // that no files linger from previous builds.
     clean: ["dist/"],
@@ -180,7 +179,6 @@ module.exports = function(grunt) {
       // Do not wrap everything in an IIFE
       wrap: false
     }
-
   });
 
   // The default task will remove all contents inside the dist/ folder, lint
@@ -218,7 +216,7 @@ module.exports = function(grunt) {
     });
 
     // Run the server
-    grunt.helper("monolithic", options);
+    monohelp(options);
 
     // Fail task if errors were logged
     if (grunt.errors) { return false; }
@@ -226,7 +224,7 @@ module.exports = function(grunt) {
     log.writeln("Doing that listening on http://" + options.host + ":" + options.port);
   });
 
-  grunt.registerHelper("monolithic", function(options) {
+  function monohelp(options) {
     // Require libraries.
     var fs = require("fs");
     var path = require("path");
@@ -497,6 +495,6 @@ module.exports = function(grunt) {
 
     // Actually listen
     site.listen(options.port, options.host);
-  });
+  }
 
 };

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bbb release monolithic:release
+web: grunt monolithic

--- a/app/templates/decorate.html
+++ b/app/templates/decorate.html
@@ -29,7 +29,7 @@
         <br/>
       
         <iframe class="twitter-share-iframe" allowtransparency="true" frameborder="0" scrolling="no" src="https://platform.twitter.com/widgets/tweet_button.html?url=http://blockee.org&count=none"></iframe> 
-        <span id="fb-button"></span>
+        <input id="fb-button" type="button" value="Post" class="uibutton confirm"/>
        <!-- <a class="twitter-share-iframe" href="http://www.tumblr.com/share" title="Share on Tumblr" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:20px; height:20px; background:url('http://platform.tumblr.com/v1/share_4T.png') top left no-repeat transparent;">Share on Tumblr</a> -->
       </div>
       <script>

--- a/app/templates/decorate.html
+++ b/app/templates/decorate.html
@@ -29,7 +29,7 @@
         <br/>
       
         <iframe class="twitter-share-iframe" allowtransparency="true" frameborder="0" scrolling="no" src="https://platform.twitter.com/widgets/tweet_button.html?url=http://blockee.org&count=none"></iframe> 
-        <input id="fb-button" type="button" value="Post" class="uibutton confirm"/>
+        <span id="fb-button"></span>
        <!-- <a class="twitter-share-iframe" href="http://www.tumblr.com/share" title="Share on Tumblr" style="display:inline-block; text-indent:-9999px; overflow:hidden; width:20px; height:20px; background:url('http://platform.tumblr.com/v1/share_4T.png') top left no-repeat transparent;">Share on Tumblr</a> -->
       </div>
       <script>

--- a/app/templates/decoratereshare.html
+++ b/app/templates/decoratereshare.html
@@ -17,7 +17,7 @@
         <input id="long_url" type="text" class="input-medium" value="http://blockee.org"/>
         <br/>      
         <iframe class="twitter-share-iframe" allowtransparency="true" frameborder="0" scrolling="no" src="https://platform.twitter.com/widgets/tweet_button.html?url=http://blockee.org&count=none"></iframe>
-        <span id="fb-button"></span>
+        <input id="fb-button" type="button" value="Post" class="uibutton confirm"/>
          <script>
   _kmq.push(['trackClick', 'fb-button', 'fb Clicked']);
 </script>

--- a/app/templates/decoratereshare.html
+++ b/app/templates/decoratereshare.html
@@ -17,7 +17,7 @@
         <input id="long_url" type="text" class="input-medium" value="http://blockee.org"/>
         <br/>      
         <iframe class="twitter-share-iframe" allowtransparency="true" frameborder="0" scrolling="no" src="https://platform.twitter.com/widgets/tweet_button.html?url=http://blockee.org&count=none"></iframe>
-        <input id="fb-button" type="button" value="Post" class="uibutton confirm"/>
+        <span id="fb-button"></span>
          <script>
   _kmq.push(['trackClick', 'fb-button', 'fb Clicked']);
 </script>

--- a/assets/js/libs/sharefeature.js
+++ b/assets/js/libs/sharefeature.js
@@ -113,6 +113,9 @@ var ShareFeature = {
       description: ''
     };
 
+    var fbButton = $('<div class="fb-share-button" data-href="' + obj.link + '" data-layout="button" data-size="small" data-mobile-iframe="false"><a class="fb-xfbml-parse-ignore" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=' + escape(obj.link) + '&amp;src=sdkpreparse">Share</a></div>');
+    $('#fb-button').html('').append(fbButton);
+
     var callback = function(response){
       console.log(response);
     };

--- a/index.html
+++ b/index.html
@@ -50,10 +50,13 @@
   
   <!-- Facebook API load and prep for fun -->
   <div id='fb-root' style='display:none;'></div>
-  <script src='//connect.facebook.net/en_US/all.js' type='text/javascript'></script>
-  <script type="text/javascript">
-    FB.init({appId: "259430777508221", status: true, cookie: true});
-  </script>  
+<script>(function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.7&appId=259430777508221";
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));</script>
   
  <script type="text/javascript" src="http://platform.tumblr.com/v1/share.js"></script> 
   

--- a/package.json
+++ b/package.json
@@ -11,8 +11,5 @@
     "request": "2.11.1",
     "imagemagick": "0.1.2",
     "underscore": "1.3.3"
-  },
-  "engines": {
-    "node": "0.6.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.1",
   "dependencies": {
     "connect": "2.3.3",
-    "bbb": "0.1.2",
     "express": "3.0",
+    "grunt": "^1.0.1",
+    "imagemagick": "0.1.2",
     "knox": "0.1.0",
     "oauth": "0.9.8",
-    "stylus": "0.28.2",
     "request": "2.11.1",
-    "imagemagick": "0.1.2",
+    "stylus": "0.28.2",
     "underscore": "1.3.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,18 @@
 {
   "name": "blockee",
   "version": "0.0.1",
-  "dependencies" : {
-    "connect"  :  "2.3.3",
-    "bbb" :  "0.1.2",
-    "express" : "3.0",
+  "dependencies": {
+    "connect": "2.3.3",
+    "bbb": "0.1.2",
+    "express": "3.0",
     "knox": "0.1.0",
     "oauth": "0.9.8",
     "stylus": "0.28.2",
     "request": "2.11.1",
     "imagemagick": "0.1.2",
     "underscore": "1.3.3"
+  },
+  "devDependencies": {
+    "grunt-bbb-server": "^0.1.2"
   }
 }


### PR DESCRIPTION
Facebook told me that Blockee.org was using a deprecated version of their Graph API to share URLs, so I patched that

In redeploying to Heroku, I needed to upgrade the backend (Node 0.6 and bbb server) to `grunt` only, and upgrade grunt from the 2012 version (0.3) to the current 1.0

I no longer have access to the repo; plz merge
